### PR TITLE
Updates updated_by on model creation

### DIFF
--- a/src/app/Traits/UpdatedBy.php
+++ b/src/app/Traits/UpdatedBy.php
@@ -6,6 +6,10 @@ trait UpdatedBy
 {
     protected static function bootUpdatedBy()
     {
+        self::creating(function ($model) {
+            $model->updated_by = optional(auth()->user())->id;
+        });
+
         self::updating(function ($model) {
             $model->updated_by = optional(auth()->user())->id;
         });


### PR DESCRIPTION
This update allow:
- make database field `updated_by` not nullable
- fits Laravel style of working with `updated_at`, `created_at`